### PR TITLE
fix(debian): Install yarn the recommended way

### DIFF
--- a/script-library/node-debian.sh
+++ b/script-library/node-debian.sh
@@ -82,17 +82,6 @@ export DEBIAN_FRONTEND=noninteractive
 # Install dependencies
 check_packages apt-transport-https curl ca-certificates tar gnupg2 dirmngr
 
-# Install yarn
-if type yarn > /dev/null 2>&1; then
-    echo "Yarn already installed."
-else
-    # Import key safely (new method rather than deprecated apt-key approach) and install
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
-    apt-get update
-    apt-get -y install --no-install-recommends yarn
-fi
-
 # Adjust node version if required
 if [ "${NODE_VERSION}" = "none" ]; then
     export NODE_VERSION=
@@ -165,5 +154,14 @@ if [ "${INSTALL_TOOLS_FOR_NODE_GYP}" = "true" ]; then
         apt-get -y install ${to_install}
     fi
 fi
+
+# Install yarn
+if type yarn > /dev/null 2>&1; then
+    echo "Yarn already installed."
+else
+    # Use the recommended way to install Yarn. Through npm
+    npm install --global yarn
+fi
+
 
 echo "Done!"


### PR DESCRIPTION
Yarn failed to install with:

```
gpg: no valid OpenPGP data found.
```

This fixes that.